### PR TITLE
Created Player detection functionality

### DIFF
--- a/Assets/Prefabs/Enemies/Enemy.prefab
+++ b/Assets/Prefabs/Enemies/Enemy.prefab
@@ -16,7 +16,7 @@ GameObject:
   - component: {fileID: 724241720}
   m_Layer: 0
   m_Name: Enemy
-  m_TagString: Untagged
+  m_TagString: Enemy
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -83,6 +83,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   patrolPoints: []
   agent: {fileID: 724241720}
+  player: {fileID: 0}
 --- !u!136 &724241726
 CapsuleCollider:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Test Scenes/JoshTest.unity
+++ b/Assets/Scenes/Test Scenes/JoshTest.unity
@@ -610,6 +610,63 @@ Mesh:
     offset: 0
     size: 0
     path: 
+--- !u!1001 &116527404
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5421670207346728186, guid: 03e7537a87da3bc468fb94b6b70d3d26, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 26.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 5421670207346728186, guid: 03e7537a87da3bc468fb94b6b70d3d26, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5421670207346728186, guid: 03e7537a87da3bc468fb94b6b70d3d26, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -24.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 5421670207346728186, guid: 03e7537a87da3bc468fb94b6b70d3d26, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5421670207346728186, guid: 03e7537a87da3bc468fb94b6b70d3d26, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5421670207346728186, guid: 03e7537a87da3bc468fb94b6b70d3d26, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5421670207346728186, guid: 03e7537a87da3bc468fb94b6b70d3d26, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5421670207346728186, guid: 03e7537a87da3bc468fb94b6b70d3d26, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5421670207346728186, guid: 03e7537a87da3bc468fb94b6b70d3d26, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5421670207346728186, guid: 03e7537a87da3bc468fb94b6b70d3d26, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5421670207346728186, guid: 03e7537a87da3bc468fb94b6b70d3d26, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5421670207346728191, guid: 03e7537a87da3bc468fb94b6b70d3d26, type: 3}
+      propertyPath: m_Name
+      value: Player
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 03e7537a87da3bc468fb94b6b70d3d26, type: 3}
 --- !u!43 &163051213
 Mesh:
   m_ObjectHideFlags: 0
@@ -1129,7 +1186,7 @@ Transform:
   - {fileID: 429290595}
   - {fileID: 50027573}
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &623928882
 PrefabInstance:
@@ -1696,6 +1753,10 @@ PrefabInstance:
       propertyPath: agent
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: -4185662969355184773, guid: 80a1ea2d8b3288048b1157664439737e, type: 3}
+      propertyPath: player
+      value: 
+      objectReference: {fileID: 1008801999}
     - target: {fileID: 1844642598771941254, guid: 80a1ea2d8b3288048b1157664439737e, type: 3}
       propertyPath: m_LocalPosition.x
       value: 6
@@ -1726,7 +1787,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1844642598771941254, guid: 80a1ea2d8b3288048b1157664439737e, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 1844642598771941254, guid: 80a1ea2d8b3288048b1157664439737e, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -1788,7 +1849,7 @@ Transform:
   - {fileID: 840371789}
   - {fileID: 653160831}
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &794052272
 PrefabInstance:
@@ -2975,6 +3036,11 @@ Mesh:
     offset: 0
     size: 0
     path: 
+--- !u!1 &1008801999 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5421670207346728191, guid: 03e7537a87da3bc468fb94b6b70d3d26, type: 3}
+  m_PrefabInstance: {fileID: 116527404}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1056631691
 GameObject:
   m_ObjectHideFlags: 0
@@ -3501,13 +3567,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1178307613}
-  m_LocalRotation: {x: 0.32650557, y: 0.6272114, z: -0.32650557, w: 0.6272114}
-  m_LocalPosition: {x: 0, y: 15.72, z: -13.72}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 15.67, y: 28.3, z: -13.72}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 55, y: 90, z: 0}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!1 &1179538452
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Characters/CharacterHealth.cs
+++ b/Assets/Scripts/Characters/CharacterHealth.cs
@@ -50,6 +50,10 @@ public class CharacterHealth : MonoBehaviour, IDamageable<int>
         // Disable the renderer and collider so that the enemy can no longer be interacted with
         myRenderer.SetActive(false);
         myCollider.enabled = false;
+        if (tag == "Enemy")
+        {
+            Destroy(gameObject);
+        }
     }
 
     public virtual void HealHP(int hpRestored)

--- a/Assets/Scripts/Characters/Enemy/EnemyNavigation.cs
+++ b/Assets/Scripts/Characters/Enemy/EnemyNavigation.cs
@@ -12,15 +12,18 @@ public class EnemyNavigation : MonoBehaviour
 
     int curPoint = 0;
     bool reverseCourse = false;
+    bool playerDetected = false;
+    bool curDelay = false;
 
     public NavMeshAgent agent;
+    public GameObject player;
 
 
     // Start is called before the first frame update
     void Start()
     {
         agent = GetComponent<NavMeshAgent>();
-
+        
         if (agent == null)
         {
             Debug.LogWarning(name + " does not have a NavMeshAgent component.");
@@ -30,7 +33,28 @@ public class EnemyNavigation : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        agent.SetDestination(patrolPoints[curPoint].transform.position);
+        if (!playerDetected)
+        {
+            agent.SetDestination(patrolPoints[curPoint].transform.position);            
+        }
+        else
+        {
+            agent.SetDestination(player.transform.position);            
+        }
+
+        RaycastHit hit;
+        Ray ray = new Ray(transform.position + new Vector3(0, 1, 0), transform.forward * 3);
+        Debug.DrawRay(transform.position + new Vector3(0, 1, 0), transform.forward * 3, Color.red);
+
+        if (Physics.Raycast(ray, out hit, 3))
+        {
+            if (hit.collider.tag == "Player")
+            {
+                playerDetected = true;
+                StopCoroutine("Delay");
+                StartCoroutine("Delay");
+            }           
+        }
     }
 
     private void OnTriggerEnter(Collider other)
@@ -54,21 +78,14 @@ public class EnemyNavigation : MonoBehaviour
             {
                 curPoint += 1;
             }
-            
-            
-            
         }
     }
 
-    /*private void OnCollisionEnter(Collision collision)
-    {
-        if (collision.gameObject.tag == "PatrolPoint")
-        {
-            curPoint += 1;
-            if (curPoint >= patrolPoints.Length)
-            {
-                curPoint = 0;
-            }
-        }
-    }*/
+    IEnumerator Delay()
+    {        
+        //Debug.Log("Coroutine has started.");
+        yield return new WaitForSeconds(3.0f);
+        playerDetected = false;        
+    }
+    
 }

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -5,6 +5,7 @@ TagManager:
   serializedVersion: 2
   tags:
   - PatrolPoint
+  - Enemy
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
The enemy AI will now detect the player when walked in front of.  They will follow the player until the player remains undetected for 3 seconds and the enemy will return to their patrol route.  Added a minor edit to the character health script to allow enemy game objects to be destroyed on death so they do not continue to raycast and run coroutines.